### PR TITLE
Correct macOS capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chris Titus Tech's MacOS Utility
+# Chris Titus Tech's macOS Utility
 
 [![Version](https://img.shields.io/github/v/release/ChrisTitusTech/macutil?color=%230567ff&label=Latest%20Release&style=for-the-badge)](https://github.com/ChrisTitusTech/macutil/releases/latest)
 ![GitHub Downloads (specific asset, all releases)](https://img.shields.io/github/downloads/ChrisTitusTech/macutil/macutil?label=Total%20Downloads&style=for-the-badge)


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/macutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

According to the official macOS page on apple.com, the correct capitalization of macOS is "macOS," while "MacOS" is deemed incorrect. However, the README.md file uses the incorrect capitalization.

## Testing, Impact, Checklist, and more
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->

This PR only alters the README file and does not have any information for other fields.
