### PR TITLE
C# port of MacUtil

### DIFF
--- a/MacUtilGUI/MacUtilGUI.csproj
+++ b/MacUtilGUI/MacUtilGUI.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    
+    <!-- Self-contained single file configuration -->
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>link</TrimMode>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.10" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
+    <PackageReference Include="Tomlyn" Version="0.17.0" />
+  </ItemGroup>
+
+  <!-- Trim-friendly settings for Avalonia -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Avalonia" />
+    <TrimmerRootAssembly Include="Avalonia.Desktop" />
+    <TrimmerRootAssembly Include="Avalonia.Themes.Fluent" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AvaloniaResource Include="Assets\**" />
+  </ItemGroup>
+
+  <!-- Include scripts as embedded resources -->
+  <ItemGroup>
+    <EmbeddedResource Include="../scripts/**/*.sh" />
+    <EmbeddedResource Include="../scripts/**/*.toml" />
+  </ItemGroup>
+
+</Project>

--- a/MacUtilGUI/Models/ScriptCategory.cs
+++ b/MacUtilGUI/Models/ScriptCategory.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace MacUtilGUI.Models;
+
+public class ScriptCategory {
+    public string Name {get; set;}
+    public List<ScriptInfo> Scripts {get; set;}
+}

--- a/MacUtilGUI/Models/ScriptInfo.cs
+++ b/MacUtilGUI/Models/ScriptInfo.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MacUtilGUI.Models;
+
+public class ScriptInfo {
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public string Script { get; set; }
+    public string TaskList { get; set; }
+    public string Category { get; set; }
+    public string FullPath { get; set; }
+}

--- a/MacUtilGUI/Program.cs
+++ b/MacUtilGUI/Program.cs
@@ -1,0 +1,40 @@
+namespace MacUtilGUI;
+using System;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using MacUtilGUI.Views;
+using MacUtilGUI.ViewModels;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+public class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow
+            {
+                DataContext = new MainWindowViewModel()
+            };
+
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
+}
+
+internal static class Program
+{
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>().UsePlatformDetect().LogToTrace();
+
+    [STAThread]
+    public static void Main(String[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+}

--- a/MacUtilGUI/Services/ScriptService.cs
+++ b/MacUtilGUI/Services/ScriptService.cs
@@ -1,0 +1,262 @@
+namespace MacUtilGUI.Services;
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Reflection;
+using System.Collections.Generic;
+using Tomlyn;
+using MacUtilGUI.Models;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Avalonia.Controls.Converters;
+
+public class ScriptService {
+
+    static Assembly assembly = Assembly.GetExecutingAssembly();
+
+    public static String getEmbeddedResource(String resourcePath) {
+        try
+        {
+            String resourceName = String.Format("MacUtilGUI.{0}", resourcePath.Replace("/", ".").Replace("\\", ".").Replace("-", "_"));
+            using (var resStream = assembly.GetManifestResourceStream(resourceName))
+            {
+                if (resStream is not null)
+                {
+                    var reader = new StreamReader(resStream);
+                    return reader.ReadToEnd();
+                }
+                else
+                {
+                    Console.WriteLine(String.Format("Resource not found: {0}", resourceName));
+                    return "";
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(String.Format("Error reading embedded resource {0}: {1}", resourcePath, ex.Message));
+        }
+        return "";
+    }
+
+    public static void listEmbeddedResources() {
+        var resourceNames = assembly.GetManifestResourceNames();
+        Console.WriteLine("Available embedded resources:");
+        foreach (String name in resourceNames) {
+            Console.WriteLine(String.Format("  {0}", name));
+        }
+    }
+
+    public static List<ScriptCategory> loadScriptsFromDirectory(String directoryPath) {
+        List<ScriptCategory> categories = [];
+
+        try
+        {
+            String tabDataPath = String.Format("{0}/tab_data.toml", directoryPath);
+            String content = getEmbeddedResource(tabDataPath);
+
+            if (!String.IsNullOrEmpty(content))
+            {
+                try
+                {
+                    var tomlDoc = Toml.Parse(content);
+
+                    if (tomlDoc.Diagnostics.Count > 0)
+                    {
+                        Console.WriteLine(String.Format("TOML parsing warnings/errors for {0}", tabDataPath));
+                        foreach (var diag in tomlDoc.Diagnostics)
+                        {
+                            Console.WriteLine(String.Format("  {0}", diag.ToString()));
+                        }
+                    }
+
+                    var table = tomlDoc.ToModel();
+
+                    if (table.ContainsKey("data") && table["data"] is Tomlyn.Model.TomlTableArray dataArray)
+                    {
+                        foreach (var dataGroup in dataArray)
+                        {
+                            if (dataGroup.ContainsKey("name") && dataGroup.ContainsKey("entries"))
+                            {
+                                String groupName = dataGroup["name"].ToString();
+                                if (dataGroup["entries"] is Tomlyn.Model.TomlTableArray entriesArray)
+                                {
+                                    var scripts = new List<ScriptInfo>();
+                                    foreach (var entry in entriesArray)
+                                    {
+                                        if (entry.ContainsKey("name") && entry.ContainsKey("description"))
+                                        {
+                                            scripts.Add(new ScriptInfo
+                                            {
+                                                Name = entry["name"].ToString(),
+                                                Description = entry["description"].ToString(),
+                                                Script = entry["script"].ToString(),
+                                                TaskList = "I",
+                                                Category = groupName,
+                                                FullPath = $"{directoryPath}/{entry["script"].ToString()}"
+                                            });     // we don't need to create variables we're only going to use once
+                                        }
+                                    }
+
+                                    if (scripts.Count > 0)
+                                    {
+                                        categories.Add(new ScriptCategory
+                                        {
+                                            Name = groupName,
+                                            Scripts = scripts
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(String.Format("Error parsing TOML file {0}: {1}", tabDataPath, ex.Message));
+                }
+            }
+            else
+            {
+                Console.WriteLine(String.Format("ERROR: Embedded resource not found: {0}", tabDataPath));
+                Console.WriteLine("This should not happen if resources are properly embedded!");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(String.Format("Error loading scripts from {0}: {1}", directoryPath, ex.Message));
+        }
+        categories.Reverse();
+        return categories;
+    }
+
+    public static List<ScriptCategory> loadAllScripts() {
+        List<ScriptCategory> allCategories = [];
+
+        try
+        {
+            if (Debugger.IsAttached)
+            {
+                // We'll leave this for the debugger
+                listEmbeddedResources();
+            }
+
+            String mainTabsPath = "tabs.toml";
+            String content = getEmbeddedResource(mainTabsPath);
+            if (!String.IsNullOrEmpty(content))
+            {
+                var tomlDoc = Toml.Parse(content);
+                var table = tomlDoc.ToModel();
+
+                if (table.ContainsKey("directories") && table["directories"] is Tomlyn.Model.TomlArray dirArray)
+                {
+                    foreach (var dir in dirArray)
+                    {
+                        allCategories.AddRange(loadScriptsFromDirectory(dir.ToString()));
+                    }
+                }
+            }
+            else
+            {
+                Console.WriteLine("ERROR: Main tabs.toml not found in embedded resources!");
+                Console.WriteLine("This should not happen if resources are properly embedded!");
+            }
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(String.Format("Error loading scripts: {0}", ex.Message));
+        }
+        return allCategories;
+    }
+
+    public static String RunScript(ScriptInfo scriptInfo)
+    {
+        try
+        {
+            String scriptContent = getEmbeddedResource(scriptInfo.FullPath);    // We first get the script and then do all processing required
+            if (!String.IsNullOrEmpty(scriptContent))
+            {
+                // Creating temp files, setting them up with data, running them...
+                String tempDir = Path.GetTempPath();
+                String scriptFileName = Path.GetFileName(scriptInfo.Script);    // equivalent of basename command in a UNIX terminal
+
+                // This yields strings like "20dc002f_fix_finder.sh". We combine this name with the %TEMP% path, and presto! We have a file path
+                String tempFileName = String.Format("{0}_{1}", Guid.NewGuid().ToString("N").Substring(0, 8), scriptFileName);
+                String tempFilePath = Path.Combine(tempDir, tempFileName);
+
+                try
+                {
+                    File.WriteAllText(tempFilePath, scriptContent);
+
+                    // Since we're talking about a UNIX environment, we'll mark the script as executable
+                    // .NET is cross-platform, so it's a good idea we check the platform we're running this on before running chmod
+
+                    // macOS yields Unix
+                    if (Environment.OSVersion.Platform == PlatformID.Unix)
+                    {
+                        Process.Start("/bin/chmod", $"+x \"{tempFilePath}\"").WaitForExit();
+                    }
+                    else
+                    {
+                        throw new Exception("Not running on UNIX!");
+                    }
+
+                    Process proc = new Process();
+                    proc.StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "/bin/bash",
+                        Arguments = $"\"{tempFilePath}\"",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    };
+
+                    String output = "";
+                    String error = "";
+
+                    proc.Start();
+                    if (proc is not null)
+                    {
+                        output = proc.StandardOutput.ReadToEnd();
+                        error = proc.StandardError.ReadToEnd();
+                    }
+                    proc.WaitForExit();
+
+                    var fullOutput = String.IsNullOrEmpty(error) ? output : String.Format("{0}\n--- ERRORS ---\n{1}", output, error);
+                    Console.WriteLine(String.Format("Executed script: {0} (Exit Code: {1})", scriptInfo.Name, proc.ExitCode));
+
+                    return fullOutput;
+                }
+                finally
+                {
+                    // Clean up stuff
+                    if (File.Exists(tempFilePath))
+                    {
+                        try
+                        {
+                            File.Delete(tempFilePath);
+                        }
+                        catch
+                        {
+                            // Do nothing
+                        }
+                    }
+                }
+            }
+            else
+            {
+                String errorMsg = String.Format("Script content not found in embedded resource: {0}", scriptInfo.FullPath);
+                Console.Write(errorMsg);
+                return errorMsg;
+            }
+        }
+        catch (Exception ex)
+        {
+            String errorMsg = String.Format("Error running script {0}: {1}", scriptInfo.Name, ex.Message);
+            Console.Write(errorMsg);
+            return errorMsg;
+        }
+    }
+}

--- a/MacUtilGUI/ViewModels/MainWindowViewModel.cs
+++ b/MacUtilGUI/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,95 @@
+namespace MacUtilGUI.ViewModels;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Avalonia.Threading;
+using MacUtilGUI.Models;
+using MacUtilGUI.Services;
+
+public class RelayCommand : ICommand
+{
+    private readonly Func<object, bool> _canExecute;
+    private readonly Action<object> _execute;
+
+    public RelayCommand(Action<object> execute) : this(_ => true, execute) { }
+
+    public RelayCommand(Func<object, bool> canExecute, Action<object> execute)
+    {
+        _canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+    }
+
+    public event EventHandler CanExecuteChanged;
+    public bool CanExecute(object parameter) => _canExecute(parameter);
+    public void Execute(object parameter) => _execute(parameter);
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}
+
+public class MainWindowViewModel : ViewModelBase
+{
+    private ScriptInfo _selectedScript;
+    private String _scriptOutput = String.Empty;
+    private readonly ObservableCollection<ScriptCategory> _categories = new();
+    public String Title = "MacUtil GUI - Script Runner";
+
+    public MainWindowViewModel()
+    {
+        SelectScriptCommand = new RelayCommand(parameter =>
+        {
+            if (parameter is ScriptInfo script)
+            {
+                _selectedScript = script;
+                _scriptOutput = String.Empty;
+                OnPropertyChanged("SelectedScript");
+                OnPropertyChanged("ScriptOutput");
+                OnPropertyChanged("CanRunScript");
+                OnPropertyChanged("SelectedScriptName");
+                OnPropertyChanged("SelectedScriptDescription");
+                OnPropertyChanged("SelectedScriptCategory");
+                OnPropertyChanged("SelectedScriptFile");
+            }
+        });
+
+        RunScriptCommand = new RelayCommand(_ =>
+        {
+            if (_selectedScript is not null)
+            {
+                _scriptOutput = "Running script";
+                OnPropertyChanged("ScriptOutput");
+
+                Task.Run(() =>
+                {
+                    var output = ScriptService.RunScript(_selectedScript);
+
+                    // Allow some threading
+                    Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        _scriptOutput = output;
+                        OnPropertyChanged("ScriptOutput");
+                    });
+                });
+            }
+        });
+
+        List<ScriptCategory> loadedCategories = ScriptService.loadAllScripts();
+        foreach (ScriptCategory category in loadedCategories)
+        {
+            _categories.Add(category);
+        }   
+    }
+
+    public ObservableCollection<ScriptCategory> Categories => _categories;
+    public ScriptInfo SelectedScript => _selectedScript;
+    public String ScriptOutput => _scriptOutput;
+    public String SelectedScriptName => (_selectedScript is not null) ? _selectedScript.Name : "";
+    public String SelectedScriptDescription => (_selectedScript is not null) ? _selectedScript.Description : "";
+    public String SelectedScriptCategory => (_selectedScript is not null) ? _selectedScript.Category : "";
+    public String SelectedScriptFile => (_selectedScript is not null) ? _selectedScript.Script : "";
+    public bool CanRunScript => _selectedScript is not null;
+    public ICommand SelectScriptCommand { get; }
+
+    public ICommand RunScriptCommand { get; }
+}

--- a/MacUtilGUI/ViewModels/ViewModelBase.cs
+++ b/MacUtilGUI/ViewModels/ViewModelBase.cs
@@ -1,0 +1,13 @@
+namespace MacUtilGUI.ViewModels;
+
+using System.ComponentModel;
+
+public class ViewModelBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/MacUtilGUI/Views/MainWindow.axaml
+++ b/MacUtilGUI/Views/MainWindow.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="700"
         x:Class="MacUtilGUI.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="{Binding Title}"
+        Title="MacUtil GUI - Script Runner"
         Width="1000" Height="700"
         MinWidth="800" MinHeight="600">
 

--- a/MacUtilGUI/Views/MainWindow.axaml.cs
+++ b/MacUtilGUI/Views/MainWindow.axaml.cs
@@ -1,0 +1,32 @@
+namespace MacUtilGUI.Views;
+
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using MacUtilGUI.ViewModels;
+using MacUtilGUI.Models;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnScriptButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && 
+            button.Tag is ScriptInfo script && 
+            DataContext is MainWindowViewModel vm)
+        {
+            ((ICommand)vm.SelectScriptCommand).Execute(script);
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [X] Refactoring

## Description
Because why not?

This is only for science. It was quite easy porting it from F# to C#.

Now, it offers an enhancement: it detects the OS platform before running scripts. Because .NET 9 applications are cross-platform and we want it to run on macOS, a check has been added. If it is run on, for example, Windows; the warning will appear:

<img width="1000" height="700" alt="MacUtilGUI_X6N3uAFbwY" src="https://github.com/user-attachments/assets/9c201ab3-137a-4df0-8fca-964236987ccd" />

## Testing
Based on my testing it works fine:

<img width="1914" height="1080" alt="msrdc_Cw80N7US3W" src="https://github.com/user-attachments/assets/3a8e81d5-85fc-4478-b545-433152122972" />

## Impact
From the least popular language to one of the most!

## Issues / other PRs related
None

## Additional Information
You decide whether to switch to C# or to keep F#. Some more maintenance and polishing may still need to be made though.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
