### PR TITLE
Platform detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ MacUtilGUI/publish/
 .Trashes
 ehthumbs.db
 Thumbs.db
+MacUtilGUI/.vs

--- a/MacUtilGUI/Services/ScriptService.fs
+++ b/MacUtilGUI/Services/ScriptService.fs
@@ -178,7 +178,7 @@ module ScriptService =
                     raise (System.Exception("Not running on UNIX!"))
 
                 // Now detect if it isn't running on macOS with osascript checks
-                if not (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform Runtime.InteropServices.OSPlatform.OSX) then
+                if not (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(Runtime.InteropServices.OSPlatform.OSX)) then
                     raise (System.Exception("Not running on macOS"))
 
                 // Get the script content from embedded resources

--- a/MacUtilGUI/Services/ScriptService.fs
+++ b/MacUtilGUI/Services/ScriptService.fs
@@ -173,6 +173,14 @@ module ScriptService =
     let runScript (scriptInfo: ScriptInfo) (onOutput: string -> unit) (onError: string -> unit) : Task<int> =
         Task.Run(fun () ->
             try
+                // Detect OS platform to avoid non-UNIX systems
+                if Environment.OSVersion.Platform <> PlatformID.Unix then
+                    raise (System.Exception("Not running on UNIX!"))
+
+                // Now detect if it isn't running on macOS with osascript checks
+                if not (File.Exists("/usr/bin/osascript")) then
+                    raise (System.Exception("Not running on macOS"))
+
                 // Get the script content from embedded resources
                 match getEmbeddedResource scriptInfo.FullPath with
                 | Some scriptContent ->

--- a/MacUtilGUI/Services/ScriptService.fs
+++ b/MacUtilGUI/Services/ScriptService.fs
@@ -178,7 +178,7 @@ module ScriptService =
                     raise (System.Exception("Not running on UNIX!"))
 
                 // Now detect if it isn't running on macOS with osascript checks
-                if not (File.Exists("/usr/bin/osascript")) then
+                if not (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform Runtime.InteropServices.OSPlatform.OSX) then
                     raise (System.Exception("Not running on macOS"))
 
                 // Get the script content from embedded resources


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
This PR adds platform detection to avoid running scripts on non-macOS systems:

- It uses native .NET properties to check if the OS platform is Unix
- It then checks if osascript exists

It also fixes gitignore if changes were to be made in Visual Studio (something I'll most probably use when making changes to MacUtil).

## Testing
Testing has worked correctly on both Windows and macOS. On Linux (WSLg) it would only display the window border.

<img width="1584" height="885" alt="devenv_iKlm2ZQwrK" src="https://github.com/user-attachments/assets/98cb9810-fa07-4d0b-a17b-e1da806f4f18" />

<img width="1072" height="833" alt="msrdc_Mbr1ygVcwg" src="https://github.com/user-attachments/assets/f622b014-e8e8-4a46-bd25-05e744a5ad79" />

## Issues / other PRs related
None

## Additional Information
It is recommmended that it be tested on Linux, but it should work fine.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
