### PR TITLE
[Enhance/OSASCRIPT] Set custom message

### DIFF
--- a/MacUtilGUI/Services/ScriptService.fs
+++ b/MacUtilGUI/Services/ScriptService.fs
@@ -259,12 +259,10 @@ module ScriptService =
                             // Note: osascript doesn't provide real-time output, so we'll get all output at the end
                             let escapedPath = tempFilePath.Replace("\"", "\\\"")
 
-                            let osascriptPrompt = "MacUtil needs your permission to make changes to your computer"
-
                             let osascriptCommand =
                                 sprintf
-                                    """osascript -e 'do shell script "\"%s\"" with prompt "\"%s\"" with administrator privileges'"""
-                                    escapedPath osascriptPrompt
+                                    """osascript -e 'do shell script "\"%s\"" with prompt \"MacUtil needs your permission to make changes to your computer\" with administrator privileges'"""
+                                    escapedPath
 
                             let startInfo = ProcessStartInfo()
                             startInfo.FileName <- "/bin/sh"

--- a/MacUtilGUI/Services/ScriptService.fs
+++ b/MacUtilGUI/Services/ScriptService.fs
@@ -259,10 +259,12 @@ module ScriptService =
                             // Note: osascript doesn't provide real-time output, so we'll get all output at the end
                             let escapedPath = tempFilePath.Replace("\"", "\\\"")
 
+                            let osascriptPrompt = "MacUtil needs your permission to make changes to your computer"
+
                             let osascriptCommand =
                                 sprintf
-                                    """osascript -e 'do shell script "\"%s\"" with administrator privileges'"""
-                                    escapedPath
+                                    """osascript -e 'do shell script "\"%s\"" with prompt "\"%s\"" with administrator privileges'"""
+                                    escapedPath osascriptPrompt
 
                             let startInfo = ProcessStartInfo()
                             startInfo.FileName <- "/bin/sh"


### PR DESCRIPTION
## Type of Change
- [X] New feature

## Description
In order to keep the user-friendliness of macOS, the message of osascript has changed to suit the tone more perfectly:

<img width="1030" height="833" alt="msrdc_Hj1915RH93" src="https://github.com/user-attachments/assets/481f2039-e6d2-4e60-afae-424eec4258d4" />

## Testing
Testing has worked successfully on macOS Sequoia 15.5

## Issues / other PRs related
None

## Additional Information
None so far

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
