### PR TITLE
Add window dragging functionality to title bar

### DIFF
--- a/MacUtilGUI/Views/MainWindow.axaml
+++ b/MacUtilGUI/Views/MainWindow.axaml
@@ -23,7 +23,7 @@
     <Border Background="#80000000" Padding="20" Classes="macos-window" CornerRadius="15">
     <Grid RowDefinitions="Auto,*">
         <!-- macOS Title Bar -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="-20,-20,-20,0" Background="#80000000">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="-20,-20,-20,0" Background="#80000000" PointerPressed="TitleBar_PointerPressed">
             <!-- Window Controls -->
             <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="16,6,0,0" Spacing="8">
                 <Button Width="12" Height="12" CornerRadius="6" Background="#FF5F57" Classes="macos-window-control" Cursor="Hand" Click="OnCloseButtonClick"/>

--- a/MacUtilGUI/Views/MainWindow.axaml.fs
+++ b/MacUtilGUI/Views/MainWindow.axaml.fs
@@ -3,6 +3,7 @@ namespace MacUtilGUI.Views
 open System.Windows.Input
 open Avalonia
 open Avalonia.Controls
+open Avalonia.Input
 open Avalonia.Markup.Xaml
 open Avalonia.Interactivity
 open MacUtilGUI.ViewModels
@@ -38,3 +39,6 @@ type MainWindow() as this =
                 | _ -> ()
             | _ -> ()
         | _ -> ()
+
+    member private this.TitleBar_PointerPressed(sender: obj, e: PointerPressedEventArgs) =
+        this.BeginMoveDrag(e)


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] UI/UX improvement

## Description
Can now drag the window around from the top bar

## Testing
Works on my Mac

## Impact
More usable
