### PR TITLE
Add AltTab for Windows-like Alt+Tab behavior

### DIFF
--- a/scripts/applications-setup/tab_data.toml
+++ b/scripts/applications-setup/tab_data.toml
@@ -143,3 +143,8 @@ script = "kitty-setup.sh"
 name = "ZSH Prompt"
 description = "The Z shell is a Unix shell that can be used as an interactive login shell and as a command interpreter for shell scripting. Zsh is an extended Bourne shell with many improvements, including some features of Bash, ksh, and tcsh. This command installs ZSH prompt and provides basic configuration."
 script = "zsh-setup.sh"
+
+[[data]]
+name = "AltTab"
+description = "AltTab brings Windows-like Alt+Tab functionality to macOS, allowing you to switch between individual windows instead of just applications. Perfect for users who work with multiple windows of the same application."
+script = "alttab-setup.sh"

--- a/scripts/applications-setup/tab_data.toml
+++ b/scripts/applications-setup/tab_data.toml
@@ -143,8 +143,3 @@ script = "kitty-setup.sh"
 name = "ZSH Prompt"
 description = "The Z shell is a Unix shell that can be used as an interactive login shell and as a command interpreter for shell scripting. Zsh is an extended Bourne shell with many improvements, including some features of Bash, ksh, and tcsh. This command installs ZSH prompt and provides basic configuration."
 script = "zsh-setup.sh"
-
-[[data]]
-name = "AltTab"
-description = "AltTab brings Windows-like Alt+Tab functionality to macOS, allowing you to switch between individual windows instead of just applications. Perfect for users who work with multiple windows of the same application."
-script = "alttab-setup.sh"

--- a/scripts/system-setup/alttab-setup.sh
+++ b/scripts/system-setup/alttab-setup.sh
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+
+. ../common-script.sh
+
+installAltTab() {
+    if ! brewprogram_exists alt-tab; then
+        printf "%b\n" "${YELLOW}Installing AltTab...${RC}"
+        brew install --cask alt-tab
+        if [ $? -ne 0 ]; then
+            printf "%b\n" "${RED}Failed to install AltTab. Please check your Homebrew installation or try again later.${RC}"
+            exit 1
+        fi
+        printf "%b\n" "${GREEN}AltTab installed successfully!${RC}"
+        
+        # Configure AltTab for optimal experience
+        configureAltTab
+    else
+        printf "%b\n" "${GREEN}AltTab is already installed.${RC}"
+        printf "%b\n" "${YELLOW}Applying configuration...${RC}"
+        configureAltTab
+    fi
+}
+
+configureAltTab() {
+    printf "%b\n" "${YELLOW}Configuring AltTab preferences...${RC}"
+    
+    # Kill AltTab if it's running to ensure clean configuration
+    pkill -f "AltTab" 2>/dev/null || true
+    
+    # Wait a moment for the process to terminate
+    sleep 1
+    
+    # Show hidden windows
+    defaults write com.lwouis.alt-tab-macos showHiddenWindows -bool true
+    
+    # Overwrite the default hold shortcut to Cmd (Windows-like behavior)
+    defaults write com.lwouis.alt-tab-macos holdShortcut -string "⌘"
+    
+    # Enable start at login
+    defaults write com.lwouis.alt-tab-macos startAtLogin -bool true
+    
+    # Start AltTab silently in the background to initialize settings
+    open -g -a "AltTab" 2>/dev/null || true
+    
+    printf "%b\n" "${GREEN}AltTab configuration applied successfully!${RC}"
+    printf "%b\n" "${CYAN}Note: You may need to grant AltTab accessibility permissions in System Settings > Privacy & Security > Accessibility${RC}"
+}
+
+checkEnv
+installAltTab
+
+printf "%b\n" "${GREEN}AltTab setup completed!${RC}"
+printf "%b\n" "${CYAN}You can now use Cmd+Tab to switch between individual windows (Windows-like behavior)${RC}"
+printf "%b\n" "${CYAN}AltTab will start automatically on your next login.${RC}"
+printf "%b\n" "${CYAN}To configure further options or start it now, find AltTab in your Applications folder.${RC}"

--- a/scripts/system-setup/alttab-setup.sh
+++ b/scripts/system-setup/alttab-setup.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -e
 
+# shellcheck source=../common-script.sh
 . ../common-script.sh
 
 installAltTab() {
     if ! brewprogram_exists alt-tab; then
         printf "%b\n" "${YELLOW}Installing AltTab...${RC}"
-        brew install --cask alt-tab
-        if [ $? -ne 0 ]; then
+        if ! brew install --cask alt-tab; then
             printf "%b\n" "${RED}Failed to install AltTab. Please check your Homebrew installation or try again later.${RC}"
             exit 1
         fi

--- a/scripts/system-setup/tab_data.toml
+++ b/scripts/system-setup/tab_data.toml
@@ -22,3 +22,8 @@ script = "fix-finder.sh"
 name = "Remove Animations"
 description = "This script is designed to remove snap packages and the snapd service from your system"
 script = "remove-animations.sh"
+
+[[data.entries]]
+name = "AltTab"
+description = "AltTab brings Windows-like Alt+Tab functionality to macOS, allowing you to switch between individual windows instead of just applications. Perfect for users who work with multiple windows of the same application."
+script = "alttab-setup.sh"


### PR DESCRIPTION
Adds AltTab installation script to provide Windows-like Alt+Tab functionality on macOS.

- Added `alttab-setup.sh` in system-setup directory
- Updated tab_data.toml to include AltTab option
- Configures Cmd+Tab shortcut and auto-start on login

Implements #22